### PR TITLE
Add missing symbols. Optional fields for Index

### DIFF
--- a/java-rest-v2/REST_methods.java
+++ b/java-rest-v2/REST_methods.java
@@ -128,8 +128,8 @@ public class REST_methods implements Closeable {
 			String symbol_id = array.getJSONObject(i).getString("symbol_id");
 			String exchange_id = array.getJSONObject(i).getString("exchange_id");
 			Symbol_type symbol_type = Symbol_type.valueOf(array.getJSONObject(i).getString("symbol_type"));
-			String asset_id_base = array.getJSONObject(i).getString("asset_id_base");
-			String asset_id_quote = array.getJSONObject(i).getString("asset_id_quote");
+			String asset_id_base = array.getJSONObject(i).optString("asset_id_base");
+			String asset_id_quote = array.getJSONObject(i).optString("asset_id_quote");
 			if (symbol_type == Symbol_type.FUTURES) {
 				Instant future_delivery_time = Instant.parse(array.getJSONObject(i).getString("future_delivery_time"));
 				result[i] = new Symbol(

--- a/java-rest-v2/Symbol_type.java
+++ b/java-rest-v2/Symbol_type.java
@@ -16,6 +16,12 @@ public enum Symbol_type {
 	FUTURES,
 	
 	/** Option contract. FX Spot derivative contract where traders agree to trade right to require buy or sell of fx spot at agreed price on exercise date */
-	OPTION;
+	OPTION,
+	
+	/** Perpetual contract. FX Spot derivative contract where traders agree to trade fx spot continously without predetermined future delivery time **/
+	PERPETUAL,
+	
+	/** Index. Statistical composite that measures changes in the economy or markets. **/
+	INDEX;
 	
 }


### PR DESCRIPTION
When running the original java tests, it fails with a couple of errors.

1) The symbols PERPETUAL & INDEX are missing.
2) The json fields asset_id_base & asset_id_quote do not exist in all symbol json's.

So I thought to make you aware and add my fixes for them.