### PR TITLE
Fixed incorrect date format

### DIFF
--- a/csharp-rest/CoinAPI.REST.V1/CoinApiRestClient.cs
+++ b/csharp-rest/CoinAPI.REST.V1/CoinApiRestClient.cs
@@ -145,7 +145,7 @@ namespace CoinAPI.REST.V1 {
         }
 
         public List<OHLCV> Ohlcv_historical_data(string symbolId, string periodId, DateTime start, DateTime end, int limit) {
-            var url = string.Format("/v1/ohlcv/{0}/history?period_id={1}&time_start={2}&time_end={3}&limit={4}", symbolId, periodId, start.ToString("yyyy-MM-dd HH:ss:mm"), end.ToString("yyyy-MM-dd HH:ss:mm"), limit);
+            var url = string.Format("/v1/ohlcv/{0}/history?period_id={1}&time_start={2}&time_end={3}&limit={4}", symbolId, periodId, start.ToString(dateFormat), end.ToString(dateFormat), limit);
             return GetData<List<OHLCV>>(url);
         }
         public List<OHLCV> Ohlcv_historical_data(string symbolId, string periodId, DateTime start, DateTime end) {


### PR DESCRIPTION
BadRequestException was being thrown due to "Wrong format of time_start parameter" in Ohlcv_historical_data(string, string, DateTime, DateTime, int). The date format was hard-coded to "yyyy-MM-dd HH:ss:mm", which is invalid. It was changed to dateFormat, which is what it appears to have been changed to in all other methods.