### PR TITLE
C# Websocket SDK - Allow Changing the heartbeat timeout and reconnect interval in Seconds Unit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /csharp-ws/CoinApi.WEBSOCKET/.vs/CoinApi.WEBSOCKET/v16
 .idea
 **/target
+
+# Visual Studo 2015 cache/options directory
+.vs/

--- a/data-api/csharp-ws/CoinAPI.WebSocket.V1/CoinApiWsClient.cs
+++ b/data-api/csharp-ws/CoinAPI.WebSocket.V1/CoinApiWsClient.cs
@@ -36,6 +36,14 @@ namespace CoinAPI.WebSocket.V1
         public DateTime? ConnectedTime { get; private set; }
         protected bool? ForceOverrideHeartbeat { get; set; } = true;
 
+
+        public CoinApiWsClient(bool isSandbox, double hbTimeoutSecs, double reconnectIntervalSecs) : this(isSandbox)
+        {
+            _hbTimeout = TimeSpan.FromSeconds(hbTimeoutSecs);
+            _reconnectInterval = TimeSpan.FromSeconds(reconnectIntervalSecs);
+        }
+
+
         public CoinApiWsClient(bool isSandbox = false)
         {
             _queueThread = new QueueThread<MessageData>();


### PR DESCRIPTION
C# Websocket SDK - add constructor overload to allow changing the heartbeat timeout in seconds and reconnect interval in seconds. Update the gitignore to ignore the local and internal visual studio 2019 cache files.