### PR TITLE
CSharp WS performance improvements

### DIFF
--- a/data-api/csharp-ws/CoinAPI.WebSocket.V1/CoinApiWsClient.cs
+++ b/data-api/csharp-ws/CoinAPI.WebSocket.V1/CoinApiWsClient.cs
@@ -81,7 +81,7 @@ namespace CoinAPI.WebSocket.V1
         {
             var data = JsonSerializer.Deserialize<MessageBase>(item.Data);
 
-            if (!Enum.TryParse(data.type, out MessageType messageType))
+            if (!data.type.TryParse(out var messageType))
             {
                 // unknown type
                 return;

--- a/data-api/csharp-ws/CoinAPI.WebSocket.V1/CoinApiWsClient.cs
+++ b/data-api/csharp-ws/CoinAPI.WebSocket.V1/CoinApiWsClient.cs
@@ -11,6 +11,7 @@ namespace CoinAPI.WebSocket.V1
 {
     public class CoinApiWsClient : ICoinApiWsClient, IDisposable
     {
+        private static readonly int ReceiveBufferSize = 8192;
         private const string UrlSandbox = "wss://ws-sandbox.coinapi.io/";
         private const string UrlProduction = "wss://ws.coinapi.io/";
 
@@ -22,7 +23,8 @@ namespace CoinAPI.WebSocket.V1
         private readonly TimeSpan _hbTimeout = TimeSpan.FromSeconds(10);
         private readonly TimeSpan _hbTimeoutCheckInterval = TimeSpan.FromSeconds(1);
         private readonly TimeSpan _reconnectInterval = TimeSpan.FromSeconds(1);
-        private DateTime _hbLastAction = DateTime.MinValue;
+        private int _hbLastAction;
+        private int _hbLastActionMaxCount;
 
         // client reference is leaked here only for testing purposes (forcing reconnects)
 #pragma warning disable IDE0069 // Disposable fields should be disposed
@@ -43,19 +45,17 @@ namespace CoinAPI.WebSocket.V1
             _reconnectInterval = TimeSpan.FromSeconds(reconnectIntervalSecs);
         }
 
-
-        public CoinApiWsClient(bool isSandbox = false)
+        public CoinApiWsClient(bool isSandbox = false) : this(isSandbox ? UrlSandbox : UrlProduction)
         {
-            _queueThread = new QueueThread<MessageData>();
-            _queueThread.ItemDequeuedEvent += _queueThread_ItemDequeuedEvent;
-            _url = isSandbox ? UrlSandbox : UrlProduction;
         }
+
         public CoinApiWsClient(string url)
         {
             _queueThread = new QueueThread<MessageData>();
             _queueThread.ItemDequeuedEvent += _queueThread_ItemDequeuedEvent;
             _url = url;
         }
+
         public void SendHelloMessage(Hello msg)
         {
             if (msg == null)
@@ -200,10 +200,13 @@ namespace CoinAPI.WebSocket.V1
 
         private async Task HeartbeatWatcher(ClientWebSocket client, CancellationTokenSource connectionCts)
         {
+            // the quantity of loops that can be performed before timing out
+            _hbLastActionMaxCount = _hbTimeout.Seconds / _hbTimeoutCheckInterval.Seconds;
+
             while (!connectionCts.IsCancellationRequested)
             {
-                var lag = DateTime.UtcNow - _hbLastAction;
-                if (lag > _hbTimeout)
+                // _hbLastAction is cleared by the connection worker, if we reach maxCount here means it hasn't gotten any message for a while
+                if (Interlocked.Increment(ref _hbLastAction) >= _hbLastActionMaxCount)
                 {
                     connectionCts.Cancel();
                     await client.CloseAsync(WebSocketCloseStatus.NormalClosure, 
@@ -217,7 +220,7 @@ namespace CoinAPI.WebSocket.V1
 
         private async Task HandleConnection(CancellationTokenSource connectionCts)
         {
-            _hbLastAction = DateTime.UtcNow;
+            Interlocked.Exchange(ref _hbLastAction, 0);
 
             using (_client = new ClientWebSocket())
             {
@@ -228,13 +231,14 @@ namespace CoinAPI.WebSocket.V1
                     ConnectedTime = DateTime.UtcNow;
                     ConnectedEvent.Set();
                     ConnectedEvent.Reset();
-                    _hbLastAction = DateTime.UtcNow;
+                    Interlocked.Exchange(ref _hbLastAction, 0);
 
                     var currentHello = HelloMessage;
                     var helloAs = new ArraySegment<byte>(JsonSerializer.Serialize(currentHello));
                     await _client.SendAsync(helloAs, WebSocketMessageType.Text, true, connectionCts.Token);
-                    _hbLastAction = DateTime.UtcNow;
+                    Interlocked.Exchange(ref _hbLastAction, 0);
 
+                    var bufferArray = new byte[ReceiveBufferSize];
                     while (_client.State == WebSocketState.Open && !connectionCts.IsCancellationRequested)
                     {
                         if (currentHello != HelloMessage)
@@ -242,10 +246,10 @@ namespace CoinAPI.WebSocket.V1
                             currentHello = HelloMessage;
                             helloAs = new ArraySegment<byte>(JsonSerializer.Serialize(currentHello));
                             await _client.SendAsync(helloAs, WebSocketMessageType.Text, true, connectionCts.Token);
-                            _hbLastAction = DateTime.UtcNow;
+                            Interlocked.Exchange(ref _hbLastAction, 0);
                         }
-                        var messageData = await WSUtils.ReceiveMessage(_client, connectionCts.Token);
-                        _hbLastAction = DateTime.UtcNow;
+                        var messageData = await WSUtils.ReceiveMessage(_client, connectionCts.Token, bufferArray);
+                        Interlocked.Exchange(ref _hbLastAction, 0);
 
                         if (messageData.MessageType == WebSocketMessageType.Close)
                         {

--- a/data-api/csharp-ws/CoinAPI.WebSocket.V1/WSUtils.cs
+++ b/data-api/csharp-ws/CoinAPI.WebSocket.V1/WSUtils.cs
@@ -11,14 +11,14 @@ namespace CoinAPI.WebSocket.V1
 {
     internal static class WSUtils
     {
-        private static readonly int ReceiveBufferSize = 8192;
 
         internal async static Task<MessageData> ReceiveMessage(
             System.Net.WebSockets.WebSocket webSocket, 
-            CancellationToken ct, 
+            CancellationToken ct,
+            byte[] bufferArray,
             long maxSize = long.MaxValue)
         {
-            ArraySegment<Byte> buffer = new ArraySegment<byte>(new Byte[ReceiveBufferSize]);
+            ArraySegment<Byte> buffer = new ArraySegment<byte>(bufferArray);
             WebSocketReceiveResult result = null;
 
             using (var ms = new MemoryStream())

--- a/data-api/csharp-ws/CoinAPI.WebSocket.V1/WSUtils.cs
+++ b/data-api/csharp-ws/CoinAPI.WebSocket.V1/WSUtils.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.IO;
+using CoinAPI.WebSocket.V1.DataModels;
 using Utf8Json;
 
 namespace CoinAPI.WebSocket.V1
@@ -57,6 +58,60 @@ namespace CoinAPI.WebSocket.V1
             await webSocket.SendAsync(data, WebSocketMessageType.Text,
                 endOfMessage: true,
                 cancellationToken: CancellationToken.None);
+        }
+
+        public static bool TryParse(this string messageTypeStr, out MessageType messageType)
+        {
+            switch (messageTypeStr)
+            {
+                case "0":
+                case "book":
+                    messageType = MessageType.book;
+                    return true;
+                case "1":
+                case "book_l3":
+                    messageType = MessageType.book_l3;
+                    return true;
+                case "2":
+                case "hearbeat":
+                    messageType = MessageType.hearbeat;
+                    return true;
+                case "3":
+                case "hello":
+                    messageType = MessageType.hello;
+                    return true;
+                case "4":
+                case "quote":
+                    messageType = MessageType.quote;
+                    return true;
+                case "5":
+                case "trade":
+                    messageType = MessageType.trade;
+                    return true;
+                case "6":
+                case "volume":
+                    messageType = MessageType.volume;
+                    return true;
+                case "7":
+                case "ohlcv":
+                    messageType = MessageType.ohlcv;
+                    return true;
+                case "8":
+                case "error":
+                    messageType = MessageType.error;
+                    return true;
+                case "9":
+                case "exrate":
+                    messageType = MessageType.exrate;
+                    return true;
+                case "10":
+                case "ticker":
+                    messageType = MessageType.ticker;
+                    return true;
+                default:
+                    messageType = MessageType.error;
+                    return false;
+            }
         }
     }
 }


### PR DESCRIPTION
- Replace ManualResetEvent for slim version
- QueueThread will try to process as many items as available as quick as
  possible
- Add helper method to parse enum
- Replace calls to DateTime.UtcNow for counter
- Reuse data array buffer
- Minor tweak for constructor code duplication